### PR TITLE
Run on miq-author: npm run build; npm run preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview --host --port 80"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.0.4",


### PR DESCRIPTION
Don't know what my problem was, but I couldn't get my host and port changes to take effect by making them in vite.config.js. Using the already defined build and preview commands and specifying the host listening and port options in the command worked fine, so I went that route in this PR. 

To run the server on miq-authot.corp.adobe.com, it's just a matter of:

cd /opt/quizauthroing
git pull
npm run build
(npm run preview&)

If you were using preview before, it's going to be problematic to use locally. Since it's trying for port 80, you'll need to use sudo. 